### PR TITLE
feat: Graceful Shutdown and Makefile Settings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,8 @@
+linters-settings:
+  govet:
+    enable:
+      - fieldalignment
+linters:
+  enable:
+    - revive
+    - govet

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+lint:
+	@echo "Checking if golangci-lint is installed..."
+	@if ! command -v golangci-lint > /dev/null; then \
+		echo "golangci-lint not found. Installing..."; \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.0.2; \
+	fi
+	@echo "Running linter..."
+	@golangci-lint run ./... --fix --verbose --config .golangci.yaml
+
+align:
+	@echo "Checking if betteralign is installed..."
+	@if ! command -v betteralign > /dev/null; then \
+		echo "betteralign not found. Installing..."; \
+		go install github.com/dkorunic/betteralign/cmd/betteralign@latest; \
+	fi
+	@echo "Running align..."
+
+	@betteralign -apply ./...
+
+.PHONY: lint align

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
+	"os/signal"
+	"syscall"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -14,13 +18,46 @@ import (
 	"github.com/throttled/throttled/v2/store/memstore"
 )
 
-func main() {
+func gracefulShutdown(apiServer *http.Server, done chan bool) {
+	// Create context that listens for the interrupt signal from the OS.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
+	// Listen for the interrupt signal.
+	<-ctx.Done()
+
+	log.Println("shutting down gracefully, press Ctrl+C again to force")
+
+	// The context is used to inform the server it has 5 seconds to finish
+	// the request it is currently handling
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := apiServer.Shutdown(ctx); err != nil {
+		log.Printf("Server forced to shutdown with error: %v", err)
+	}
+
+	log.Println("Server exiting")
+
+	// Notify the main goroutine that the shutdown is complete
+	done <- true
+}
+
+func main() {
 	cfg := config.LoadConfig()
 
 	mongoClient := db.ConnectDB(cfg.MongoURI)
 
 	router := mux.NewRouter()
+
+	// Create a done channel to signal when the shutdown is complete
+	done := make(chan bool, 1)
+
+	apiServer := &http.Server{
+		Addr:    ":8080",
+		Handler: router,
+	}
+
+	go gracefulShutdown(apiServer, done)
 
 	routes.SetupRoutes(router, mongoClient)
 
@@ -46,7 +83,25 @@ func main() {
 		VaryBy:      &throttled.VaryBy{Path: true},
 	}
 
-	// Start server
-	log.Println("Server running on :8080")
-	log.Fatal(http.ListenAndServe(":8080", httpRateLimiter.RateLimit(router)))
+	// Apply rate limiting middleware to the router
+	router.Use(httpRateLimiter.RateLimit)
+
+	// Start the server in a goroutine so that it doesn't block
+	go func() {
+		log.Println("Server running on :8080")
+		if err := apiServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("ListenAndServe(): %s", err)
+		}
+	}()
+
+	// Wait for the shutdown signal
+	<-done
+	log.Println("Server has shut down gracefully")
+
+	// Close the MongoDB connection
+	if err := mongoClient.Disconnect(context.Background()); err != nil {
+		log.Printf("Error disconnecting from MongoDB: %v", err)
+	} else {
+		log.Println("Disconnected from MongoDB")
+	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/common-nighthawk/go-figure"
 	"github.com/farhan-helmy/sedekahje-be/internal/config"
 	"github.com/farhan-helmy/sedekahje-be/internal/db"
 	"github.com/farhan-helmy/sedekahje-be/internal/routes"
@@ -88,6 +89,8 @@ func main() {
 
 	// Start the server in a goroutine so that it doesn't block
 	go func() {
+		myFigure := figure.NewFigure("Sedekahje", "", true)
+		myFigure.Print()
 		log.Println("Server running on :8080")
 		if err := apiServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatalf("ListenAndServe(): %s", err)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/bsm/ginkgo/v2 v2.7.0/go.mod h1:AiKlXPm7ItEHNc/2+OkrNG4E0ITzojb9/xWzvQ
 github.com/bsm/gomega v1.26.0/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be h1:J5BL2kskAlV9ckgEsNQXscjIaLiOYiZ75d4e94E6dcQ=
+github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod h1:mk5IQ+Y0ZeO87b858TlA645sVcEcbiX6YqP98kt+7+w=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -61,7 +61,7 @@ func createInstitution(institutionService *services.InstitutionService) http.Han
 			return
 		}
 
-		if err := institutionService.CreateInstitution(institution); err != nil {
+		if err := institutionService.CreateInstitution(&institution); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/internal/services/institution_service.go
+++ b/internal/services/institution_service.go
@@ -18,7 +18,7 @@ func NewInstitutionService(client *mongo.Client) *InstitutionService {
 	return &InstitutionService{collection}
 }
 
-func (s *InstitutionService) CreateInstitution(institution models.Institution) error {
+func (s *InstitutionService) CreateInstitution(institution *models.Institution) error {
 	if _, err := s.collection.InsertOne(context.Background(), institution); err != nil {
 		return err
 	}
@@ -32,7 +32,6 @@ func (s *InstitutionService) GetInstitutions() ([]models.Institution, error) {
 	var institutions []models.Institution
 
 	cursor, err := s.collection.Find(context.Background(), bson.M{})
-
 	if err != nil {
 		return nil, err
 	}
@@ -46,10 +45,10 @@ func (s *InstitutionService) GetInstitutions() ([]models.Institution, error) {
 	return institutions, nil
 }
 
-func (s *InstitutionService) GetInstitutionBySlug(slug string) (models.Institution, error) {
+func (s *InstitutionService) GetInstitutionBySlug(slug string) (*models.Institution, error) {
 	var institution models.Institution
 
 	err := s.collection.FindOne(context.Background(), bson.M{"slug": slug}).Decode(&institution)
 
-	return institution, err
+	return &institution, err
 }


### PR DESCRIPTION
This pull request includes several significant changes to improve the codebase, enhance server shutdown handling, and update the institution service. The most important changes are grouped by theme below.

### Server Improvements:
* Added graceful shutdown handling in `cmd/server/main.go` to ensure the server shuts down properly on receiving interrupt signals and waits for ongoing requests to complete. [[1]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eL17-R62) [[2]](diffhunk://#diff-53cd25fc908d5e63cc8675afbd4ff0910572a985a7cfec27f4460eb674f3b98eL49-R109)
* Updated the `Makefile` to include new targets for linting and field alignment using `golangci-lint` and `betteralign`.

### Linting and Configuration:
* Updated `.golangci.yaml` to enable `revive` and `govet` linters, and configured `govet` to check for field alignment issues.
* Added `github.com/common-nighthawk/go-figure` to `go.mod` for displaying a banner when the server starts.

### Institution Service Enhancements:
* Modified `CreateInstitution` and `GetInstitutionBySlug` methods in `internal/services/institution_service.go` to use pointers for `models.Institution` to improve performance and memory usage. [[1]](diffhunk://#diff-fcea97cd12c0a0a32f8b8b55ad9c10e5d46c39c305b415ee22ae1ef83f5be29cL21-R21) [[2]](diffhunk://#diff-fcea97cd12c0a0a32f8b8b55ad9c10e5d46c39c305b415ee22ae1ef83f5be29cL49-R53)
* Updated the `createInstitution` handler in `internal/routes/routes.go` to pass a pointer to `institutionService.CreateInstitution`.