### PR TITLE
feat: add proper custom error handling

### DIFF
--- a/internal/errors/error.go
+++ b/internal/errors/error.go
@@ -1,0 +1,50 @@
+package errors
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type CustomError struct {
+	OriginalErr error  `json:"-"`
+	Message     string `json:"message,omitempty"`
+	StatusCode  int    `json:"status,omitempty"`
+}
+
+// Error returns the error message
+func (e *CustomError) Error() string {
+	if e.OriginalErr != nil {
+		return fmt.Sprintf("%s: %v", e.Message, e.OriginalErr)
+	}
+	return e.Message
+}
+
+// Unwrap returns the original error
+func (e *CustomError) Unwrap() error {
+	return e.OriginalErr
+}
+
+// New creates a new CustomError with an optional original error
+func New(message string, statusCode int, originalErr error) *CustomError {
+	return &CustomError{
+		Message:     message,
+		StatusCode:  statusCode,
+		OriginalErr: originalErr,
+	}
+}
+
+func Render(w http.ResponseWriter, err error, originalErr error) {
+	c, ok := err.(*CustomError)
+
+	if ok {
+		var errorMessage string
+		if originalErr != nil {
+			errorMessage = fmt.Sprintf("%s - %v", c.Message, originalErr)
+		} else {
+			errorMessage = c.Message
+		}
+		http.Error(w, errorMessage, c.StatusCode)
+	} else {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/internal/errors/institution.error.go
+++ b/internal/errors/institution.error.go
@@ -1,0 +1,22 @@
+package errors
+
+import (
+	"net/http"
+)
+
+var (
+	ErrInstitutionNotFound = &CustomError{
+		Message:    "Institution not found",
+		StatusCode: http.StatusNotFound,
+	}
+
+	ErrInstitutionAlreadyExists = &CustomError{
+		Message:    "Institution already exists",
+		StatusCode: http.StatusConflict,
+	}
+
+	ErrEmptyInstitution = &CustomError{
+		Message:    "Institution is empty",
+		StatusCode: http.StatusNotFound,
+	}
+)


### PR DESCRIPTION
This pull request introduces a new custom error handling system to improve error management across the application. It includes the creation of a `CustomError` type, predefined error instances for common scenarios, and updates to the routes to use the new error handling mechanism.

### Error Handling Enhancements:

* [`internal/errors/error.go`](diffhunk://#diff-c0273f32b09cdb0db56a52a351cf06c79369507aec46d188d0189774b063b582R1-R50): Added a `CustomError` type with fields for the original error, message, and status code. Implemented methods for error message formatting and unwrapping the original error. Added a `Render` function to send formatted error responses.
* [`internal/errors/institution.error.go`](diffhunk://#diff-d9f62e78f54660ca9963c025aefc63e0d67dd8c76bedc5d6f3d64fe64c99130fR1-R22): Defined specific error instances for common institution-related errors such as not found, already exists, and empty institution.

### Route Updates:

* [`internal/routes/routes.go`](diffhunk://#diff-8916c4df6a76d9a9d01c7411922d5f980c5cbaad5848ecf18679e294645712d0R7): Imported the new `errors` package to utilize the custom error handling.
* [`internal/routes/routes.go`](diffhunk://#diff-8916c4df6a76d9a9d01c7411922d5f980c5cbaad5848ecf18679e294645712d0L34-R44): Updated the `getAllInstitutions` function to use the `Render` method for handling `mongo.ErrNilDocument` and other errors.
* [`internal/routes/routes.go`](diffhunk://#diff-8916c4df6a76d9a9d01c7411922d5f980c5cbaad5848ecf18679e294645712d0L55-R60): Modified the `createInstitution` function to use the `Render` method for handling JSON decoding errors and institution creation errors. [[1]](diffhunk://#diff-8916c4df6a76d9a9d01c7411922d5f980c5cbaad5848ecf18679e294645712d0L55-R60) [[2]](diffhunk://#diff-8916c4df6a76d9a9d01c7411922d5f980c5cbaad5848ecf18679e294645712d0L65-R70)
* [`internal/routes/routes.go`](diffhunk://#diff-8916c4df6a76d9a9d01c7411922d5f980c5cbaad5848ecf18679e294645712d0L78-R89): Updated the `getInstitutionBySlug` function to use the `Render` method for handling `mongo.ErrNoDocuments` and other errors.